### PR TITLE
[3] Add NotFoundError, DefaultHandler

### DIFF
--- a/calm/ex.py
+++ b/calm/ex.py
@@ -55,6 +55,12 @@ class MethodNotAllowedError(ClientError):
     message = "Method not allowed"
 
 
+class NotFoundError(ClientError):
+    """Error when the requested URL is not found."""
+    code = 404
+    message = "Resource not found"
+
+
 class ServerError(CalmError):
     """The root class for server errors."""
     pass

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,7 +4,7 @@ import pytz
 
 from calm.testing import CalmTestCase
 from calm import Application
-from calm.ex import DefinitionError, MethodNotAllowedError
+from calm.ex import DefinitionError, MethodNotAllowedError, NotFoundError
 
 
 app = Application()
@@ -147,6 +147,15 @@ class CoreTests(CalmTestCase):
                       self.get_calm_app().config[
                           'error_key'
                       ]: MethodNotAllowedError.message
+                  })
+
+    def test_url_not_found(self):
+        self.post('/not_found',
+                  expected_code=404,
+                  expected_json_body={
+                      self.get_calm_app().config[
+                          'error_key'
+                      ]: NotFoundError.message
                   })
 
     def test_server_error(self):


### PR DESCRIPTION
### Problem

When requested url is not found, html page was displayed instead of showing 404 Not found error in JSON format.

### Solution

Implement `NotFoundError` by extending the root class for client errors `ClientError`, add `DefaultHandler` class by extending the main request handler `MainHandler` and implementing prepare method for raising `NotFoundError`. Pass `DefaultHandler` to the tornado’s `Application` as a default_handler_class