### PR TITLE
[11] Add support for adding Tornado `RequestHandler`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,46 @@ $ curl 'localhost:8888/my_service/args_demo/0?arg1=12&arg2=hello'
 {"type(arg1)": "<class 'int'>", "type(number)": "<class 'int'>", "arg2": "hello"}
 ```
 
+### Adding custom `RequestHandler` implementations
+
+If you have a custom Tornado `RequestHandler` implementation, you can easily add
+them to your Calm application in one of the two ways:
+
+* using the `Application.add_handler` method
+* using the `Application.custom_handler` decorator
+
+For the first option, you can just define the custom handler and manually add it
+to the Calm application, just like you would define a Tornado application:
+
+```python
+class MyHandler(RequestHandler):
+    def get(self):
+        self.write('Hello Custom Handler!')
+
+app.add_handler('/custom_handler', MyHandler)
+```
+
+The second option might look more consistent with other Calm-style definitions:
+
+```python
+@app.custom_handler('/custom_handler')
+class MyHandler(RequestHandler):
+    def get(self):
+        self.write('Hello Custom Handler!')
+```
+
+You can also use the `custom_handler` decorator of services, e.g.:
+
+
+```python
+custom_service = app.service('/custom')
+
+@custom_service.custom_handler('/custom_handler')
+class MyHandler(RequestHandler):
+    def get(self):
+        self.write('Hello Custom Handler!')
+```
+
 ## Contributions
 
 Calm loves Pull Requests and welcomes any contribution be it an issue,

--- a/calm/core.py
+++ b/calm/core.py
@@ -48,6 +48,7 @@ class CalmApp(object):
 
         self._app = None
         self._route_map = defaultdict(dict)
+        self._custom_handlers = []
         self._ws_map = {}
 
     def configure(self, **kwargs):
@@ -78,6 +79,9 @@ class CalmApp(object):
                 (uri, MainHandler, init_params)
             )
 
+        for url_spec in self._custom_handlers:
+            route_defs.append(url_spec)
+
         for uri, handler in self._ws_map.items():
             route_defs.append(
                 (uri, handler)
@@ -88,6 +92,28 @@ class CalmApp(object):
                                 default_handler_args=default_handler_args)
 
         return self._app
+
+    def add_handler(self, *url_spec):
+        """Add a custom `RequestHandler` implementation to the app."""
+        self._custom_handlers.append(url_spec)
+
+    def custom_handler(self, *uri_fragments, init_args=None):
+        """
+        Decorator for custom handlers.
+
+        A custom `RequestHandler` implementation decorated with this decorator
+        will be added to the application uti the specified `uri` and
+        `init_args`.
+        """
+        def wrapper(klass):
+            """Adds the `klass` as a custom handler and returns it back."""
+            self.add_handler(self._normalize_uri(*uri_fragments),
+                             klass,
+                             init_args)
+
+            return klass
+
+        return wrapper
 
     def _normalize_uri(self, *uri_fragments):
         """Convert colon-uri into a regex."""

--- a/calm/service.py
+++ b/calm/service.py
@@ -45,3 +45,7 @@ class CalmService(object):
     def delete(self, *url):
         """Extends the DELETE HTTP method decorator."""
         return self._app.delete(self._url, *url)
+
+    def custom_handler(self, *url, init_args=None):
+        """Extends the custom handler addition to support services."""
+        return self._app.custom_handler(self._url, *url, init_args=init_args)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 import pytz
+from tornado.web import RequestHandler
 
 from calm.testing import CalmHTTPTestCase
 from calm import Application
@@ -67,6 +68,15 @@ def argument_types(request, arg1, arg2: int):
 @app.post('/json/body')
 def json_body(request):
     return request.body
+
+
+custom_service = app.service('/custom')
+
+
+@custom_service.custom_handler('/handler')
+class MyHandler(RequestHandler):
+    def get(self):
+        self.write("custom result")
 
 
 class CoreTests(CalmHTTPTestCase):
@@ -236,3 +246,8 @@ class CoreTests(CalmHTTPTestCase):
                   })
 
         app.configure(**old_config)
+
+    def test_custom_handler(self):
+        self.get('/custom/handler',
+                 expected_code=200,
+                 expected_body='custom result')


### PR DESCRIPTION
This enables adding regular Tornado `RequestHandler` implementations to a Calm application.

@mivade please review and see if this is what you are looking for.

resolves #11 
